### PR TITLE
fix(git): push-tags

### DIFF
--- a/src/git/doGitPushTags.ts
+++ b/src/git/doGitPushTags.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
 
 export default function () {
-  spawnSync("git", ["push"]);
+  spawnSync("git", ["push", "--tags"]);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export { default as getCommits } from "./git/getCommits";
 export { default as getLastTag } from "./git/getLastGitTag";
 export { default as gitPush } from "./git/doGitPush";
+export { default as gitPushTags } from "./git/doGitPushTags";
 export { default as gitCommit } from "./git/doGitCommit";
 export { default as gitTag } from "./git/doGitTag";
 export { default as npmBumpVersion } from "./npm/doNpmBumpVersion";


### PR DESCRIPTION
I thought git push --tags was adding the tags to the default refspecs that are pushed, but that's not the case.

> When the command line does not specify what to push with <refspec>... arguments or --all, --mirror, --tags options, the command finds the default <refspec> by consulting remote.*.push configuration, and if it is not found, honors push.default configuration to decide what to push (See [git-config[1]](https://git-scm.com/docs/git-config) for the meaning of push.default).

https://git-scm.com/docs/git-push#_description

To fix the issue, I removed all flags from gitPush so it push the default refspec and added a gitPushTag method