### PR TITLE
feat(pnpm): add a set of functions

### DIFF
--- a/src/git/getGitRemote.ts
+++ b/src/git/getGitRemote.ts
@@ -1,0 +1,5 @@
+import { spawnSync } from "node:child_process";
+
+export default function () {
+  return spawnSync("git", ["remote"], { encoding: "utf-8" }).stdout.trim();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,15 @@
 export { default as getCommits } from "./git/getCommits";
 export { default as getLastTag } from "./git/getLastGitTag";
+export { default as getRemoteName } from "./git/getGitRemote";
 export { default as gitPush } from "./git/doGitPush";
 export { default as gitPushTags } from "./git/doGitPushTags";
 export { default as gitCommit } from "./git/doGitCommit";
 export { default as gitTag } from "./git/doGitTag";
 export { default as npmBumpVersion } from "./npm/doNpmBumpVersion";
 export { default as npmPublish } from "./npm/doNpmPublish";
+export { default as pnpmBumpVersion } from "./pnpm/doPnpmBumpVersion";
+export { default as pnpmGetChangedPackages } from "./pnpm/getPnpmChangedPackages";
+export { default as pnpmPublish } from "./pnpm/doPnpmPublishVersions";
 export { default as writeChangelog } from "./changelog/doWriteChangelog";
 export { default as generateChangelog } from "./changelog/getChangelog";
 export { default as getNextVersion } from "./version/getNextVersion";

--- a/src/pnpm/doPnpmBumpVersion.ts
+++ b/src/pnpm/doPnpmBumpVersion.ts
@@ -1,0 +1,22 @@
+import { runOnChanged } from "./utils/runOnChanged";
+
+/**
+ * Bump all changed packages to version {newVersion}
+ * @param newVersion the version to bump can be a version number or bump type
+ * @param since selects all the packages changed since the specified commit/branch/tag
+ * @param forcePackages also bump the version in those packages
+ * @param excludePackages filter out the specified packages/directory from the output
+ */
+export default function (
+  newVersion: string,
+  since: string,
+  forcePackages: string[] = [],
+  excludePackages: string[] = []
+): void {
+  runOnChanged(
+    `pnpm version ${newVersion} --no-git-tag-version`,
+    since,
+    forcePackages,
+    excludePackages
+  );
+}

--- a/src/pnpm/doPnpmPublishVersions.ts
+++ b/src/pnpm/doPnpmPublishVersions.ts
@@ -1,0 +1,33 @@
+import { spawnSync } from "node:child_process";
+import getOptionalArgument from "../utils/getOptionalArgument";
+import getExclusionFilters from "./utils/getExclusionFilters";
+import getIncludeFilters from "./utils/getIncludeFilters";
+
+/**
+ * Bump all changed packages to version {newVersion}
+ * @param since selects all the packages changed since the specified commit/branch/tag
+ * @param tag publishes the package with the given tag
+ * @param branch primary branch of the repository which is used for publishing the latest changes
+ * @param forcePackages also bump the version in those packages
+ * @param excludePackages filter out the specified packages/directory from the output
+ */
+export default function (
+  since: string,
+  tag?: string,
+  branch?: string,
+  forcePackages: string[] = [],
+  excludePackages: string[] = []
+): void {
+  const pnpmArgs = [
+    "--recursive",
+    `--filter="...[${since}]"`,
+    ...getIncludeFilters(forcePackages),
+    ...getExclusionFilters(excludePackages),
+    "publish",
+  ].concat(
+      getOptionalArgument('--tag', tag),
+      getOptionalArgument('--publish-branch', branch)
+  );
+
+  spawnSync("pnpm", pnpmArgs);
+}

--- a/src/pnpm/getPnpmChangedPackages.ts
+++ b/src/pnpm/getPnpmChangedPackages.ts
@@ -1,0 +1,14 @@
+import { runOnChanged } from "./utils/runOnChanged";
+
+/**
+ * Get the name of every package that changed
+ * @param since selects all the packages changed since the specified commit/branch/tag
+ * @param excludePackages filter out the specified packages/directory from the output
+ * @return an array representing the output of the command in each changed package
+ */
+export default function (
+  since: string,
+  excludePackages: string[] = []
+): string[] {
+  return runOnChanged("printenv PNPM_PACKAGE_NAME", since, [], excludePackages);
+}

--- a/src/pnpm/utils/getExclusionFilters.ts
+++ b/src/pnpm/utils/getExclusionFilters.ts
@@ -1,0 +1,3 @@
+export default function (excludePackages: string[]) {
+  return excludePackages.map((exclude: string) => `--filter="!${exclude}"`);
+}

--- a/src/pnpm/utils/getIncludeFilters.ts
+++ b/src/pnpm/utils/getIncludeFilters.ts
@@ -1,0 +1,3 @@
+export default function (includePackages: string[]) {
+  return includePackages.map((include: string) => `--filter="${include}"`);
+}

--- a/src/pnpm/utils/runOnChanged.ts
+++ b/src/pnpm/utils/runOnChanged.ts
@@ -1,0 +1,34 @@
+import { spawnSync } from "node:child_process";
+import getExclusionFilters from "./getExclusionFilters";
+import getIncludeFilters from "./getIncludeFilters";
+
+export const runOnChanged = (
+  cmd: string,
+  since: string,
+  forcePackages: string[],
+  excludePackages: string[]
+): string[] => {
+  const pnpmArgs = [
+    "--recursive",
+    `--filter="...[${since}]"`,
+    ...getIncludeFilters(forcePackages),
+    ...getExclusionFilters(excludePackages),
+    "exec",
+    "--",
+    cmd,
+  ];
+
+  try {
+    const out = spawnSync("pnpm", pnpmArgs, {
+      encoding: "utf-8",
+      shell: true,
+    }).stdout.trim();
+    if (out.includes("No projects matched the filters in")) {
+      return [];
+    }
+    return out.split("\n");
+  } catch (e) {
+    // pnpm throws an error if no packages changed.
+    return [];
+  }
+};

--- a/src/utils/getOptionalArgument.ts
+++ b/src/utils/getOptionalArgument.ts
@@ -1,0 +1,6 @@
+export default function (key: string, value?: string): string[] {
+  if (value !== undefined) {
+    return [key, value];
+  }
+  return [];
+}

--- a/src/utils/getOptionalArgument.ts
+++ b/src/utils/getOptionalArgument.ts
@@ -1,6 +1,3 @@
 export default function (key: string, value?: string): string[] {
-  if (value !== undefined) {
-    return [key, value];
-  }
-  return [];
+  return value ?? [key, value]  : [];
 }

--- a/src/version/getNextVersion.ts
+++ b/src/version/getNextVersion.ts
@@ -2,8 +2,21 @@ import type { ReleaseType, SemVer } from "semver";
 import semver from "semver";
 const { inc } = semver;
 
-const VERSION: Array<ReleaseType> = ["major", "minor", "patch"];
+const VERSION_LEVEL: Array<ReleaseType> = ["major", "minor", "patch"];
 
-export default function (version: SemVer, bumpInfo: { level: 0 | 1 | 2 }) {
-  return inc(version.version, VERSION[bumpInfo.level]);
+type BumpInfoWithLevel = { level: 0 | 1 | 2 };
+type BumpInfoWithType = { type: ReleaseType; preid?: string };
+type BumpInfo = BumpInfoWithLevel | BumpInfoWithType;
+
+function getNextVersion(version: SemVer, bumpInfo: BumpInfoWithLevel): string;
+function getNextVersion(version: SemVer, bumpInfo: BumpInfoWithType): string;
+
+function getNextVersion(version: SemVer, bumpInfo: BumpInfo) {
+  if ("level" in bumpInfo) {
+    return inc(version.version, VERSION_LEVEL[bumpInfo.level]);
+  } else {
+    return inc(version.version, bumpInfo.type, bumpInfo.preid);
+  }
 }
+
+export default getNextVersion;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "sourceMap": false,
-    "declaration": true,
+    "declaration": true
   },
+  "include": ["src"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
I added some functions to work with a PNPM project:

1. One to get the name of the package that have changed
2. One to bump a version
3. One to publish the new version

I also took the liberty to make the getNextVersion a bit more flexible, allowing you to send a specific bump type instead of a level
e.g., `getNextVersion(currentVersion, {type: "patch"});` or `getNextVersion(currentVersion, {type: "prerelease", preid: "next"});`.

The old pattern still behave as it did before