### PR TITLE
fix(utils): bad usage of nullish coalescing

### DIFF
--- a/src/utils/getOptionalArgument.ts
+++ b/src/utils/getOptionalArgument.ts
@@ -1,3 +1,3 @@
 export default function (key: string, value?: string): string[] {
-  return value ?? [key, value]  : [];
+  return value ? [key, value]  : [];
 }


### PR DESCRIPTION
I mixed several things in my suggestion.

`??` is used as a replacement for `||` for coalescing (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator)

Not as a replacement for`?` in a ternary.

Also, I don't think we outta keep the empty string for optional arguments, so I used a falsy check thru a ternary.