### PR TITLE
fix(pnpm, publish): return the spawned process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7567,7 +7567,7 @@
         "@types/semver": "^7.3.9",
         "@typescript-eslint/eslint-plugin": "^5.12.0",
         "@typescript-eslint/parser": "^5.12.0",
-        "conventional-changelog-angular": "*",
+        "conventional-changelog-angular": "^5.0.13",
         "conventional-changelog-writer": "^5.0.1",
         "conventional-commits-parser": "^3.2.4",
         "debug": "^4.3.3",

--- a/src/pnpm/__tests__/doPnpmPublishVersion.spec.ts
+++ b/src/pnpm/__tests__/doPnpmPublishVersion.spec.ts
@@ -109,4 +109,11 @@ describe("doPnpmPublishVersions", () => {
       { encoding: "utf-8" }
     );
   });
+
+  it("returns the spawned process", () => {
+    (spawnSync as any as jest.SpyInstance).mockReturnValue("returned value");
+    const returned = publish("v1.0.0");
+
+    expect(returned).toBe("returned value");
+  });
 });

--- a/src/pnpm/__tests__/doPnpmPublishVersion.spec.ts
+++ b/src/pnpm/__tests__/doPnpmPublishVersion.spec.ts
@@ -1,17 +1,20 @@
 import { spawnSync } from "node:child_process";
 import publish from "../doPnpmPublishVersions.js";
 
-jest.mock("node:child_process", () => ({
-  spawnSync: jest.fn(),
-}));
+jest.mock("node:child_process");
+const mockedSpawnSync = jest.mocked(spawnSync, true);
 
 describe("doPnpmPublishVersions", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
   it.each(["v1.0.0", "release-42"])(
     `publishes recursively with the since %s filter`,
     (since) => {
       publish(since);
 
-      expect(spawnSync).toHaveBeenCalledWith(
+      expect(mockedSpawnSync).toHaveBeenCalledWith(
         "pnpm",
         ["--recursive", `--filter="...[${since}]"`, "publish"],
         { encoding: "utf-8" }
@@ -22,7 +25,7 @@ describe("doPnpmPublishVersions", () => {
   it.each(["next", "alpha", "latest"])("publishes with the %s tag", (tag) => {
     publish("v1.0.0", tag);
 
-    expect(spawnSync).toHaveBeenCalledWith(
+    expect(mockedSpawnSync).toHaveBeenCalledWith(
       "pnpm",
       ["--recursive", '--filter="...[v1.0.0]"', "publish", "--tag", tag],
       { encoding: "utf-8" }
@@ -34,7 +37,7 @@ describe("doPnpmPublishVersions", () => {
     (branch) => {
       publish("v1.0.0", "", branch);
 
-      expect(spawnSync).toHaveBeenCalledWith(
+      expect(mockedSpawnSync).toHaveBeenCalledWith(
         "pnpm",
         [
           "--recursive",
@@ -51,7 +54,7 @@ describe("doPnpmPublishVersions", () => {
   it("filters in the forced packages", () => {
     publish("v1.0.0", "", "", ["@org/package-a", "@org/package-b"]);
 
-    expect(spawnSync).toHaveBeenCalledWith(
+    expect(mockedSpawnSync).toHaveBeenCalledWith(
       "pnpm",
       [
         "--recursive",
@@ -67,7 +70,7 @@ describe("doPnpmPublishVersions", () => {
   it("filters out the excluded packages", () => {
     publish("v1.0.0", "", "", [], ["@org/package-a", "@org/package-b"]);
 
-    expect(spawnSync).toHaveBeenCalledWith(
+    expect(mockedSpawnSync).toHaveBeenCalledWith(
       "pnpm",
       [
         "--recursive",
@@ -89,7 +92,7 @@ describe("doPnpmPublishVersions", () => {
       ["package-c", "package-d"]
     );
 
-    expect(spawnSync).toHaveBeenCalledWith(
+    expect(mockedSpawnSync).toHaveBeenCalledWith(
       "pnpm",
       [
         "--recursive",
@@ -111,9 +114,7 @@ describe("doPnpmPublishVersions", () => {
   });
 
   it("returns the spawned process", () => {
-    (spawnSync as any as jest.SpyInstance).mockReturnValue("returned value");
     const returned = publish("v1.0.0");
-
-    expect(returned).toBe("returned value");
+    expect(returned).toBe(mockedSpawnSync.mock.results[0].value);
   });
 });

--- a/src/pnpm/doPnpmPublishVersions.ts
+++ b/src/pnpm/doPnpmPublishVersions.ts
@@ -29,5 +29,5 @@ export default function (
     getOptionalArgument("--tag", tag),
     getOptionalArgument("--publish-branch", branch)
   );
-  spawnSync("pnpm", pnpmArgs, pnpmLogger);
+  return spawnSync("pnpm", pnpmArgs, pnpmLogger);
 }


### PR DESCRIPTION
The process not being returned make it harder to debug. With the flag we could see the command that was run, but not the output