### PR TITLE
ci(cd): group up release to avoid release spam

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,8 +2,13 @@ name: CD
 on:
   push:
     branches: [main]
+
+concurrency:
+  group: Release
+  cancel-in-progress: true
+
 jobs:
-  CI:
+  CD:
     runs-on: ubuntu-latest
     environment: Release
     name: CD


### PR DESCRIPTION
Let's say we merged several PRs together, we may want to avoid doing a lot of releases just for that.

To alleviate that, we can use two features of GitHub:

Environments:
![image](https://user-images.githubusercontent.com/12366410/161306879-06241ae3-423c-4cf0-9fcd-a242415c5152.png)
They allow to set up a 'timer' before a job or step proceeds. 

Concurrency: This allows to ensure that only one job per group key (here, Release) is running at a time.

Combined we have the following behavior: "When push on main, then wait for X minutes before running CD. If another push occurs during that time, use the commit of this new push and restart the timer"