### PR TITLE
ci: add dummy CI checks+wait for it

### DIFF
--- a/.github/workflows/dummy-ci.yml
+++ b/.github/workflows/dummy-ci.yml
@@ -1,0 +1,11 @@
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+name: CI
+on:
+  release:
+
+jobs:
+  CI:
+    runs-on: ubuntu-latest
+    name: CI
+    steps:
+      - run: 'echo "No build required" '

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       "devDependencies": {
         "@coveo/semantic-monorepo-tools": "file:.",
         "@octokit/auth-app": "^3.6.1",
+        "@types/async-retry": "^1.4.4",
         "@types/conventional-changelog-writer": "^4.0.1",
         "@types/conventional-commits-parser": "^3.0.2",
         "@types/debug": "^4.1.7",
@@ -27,6 +28,7 @@
         "@types/semver": "^7.3.9",
         "@typescript-eslint/eslint-plugin": "^5.12.0",
         "@typescript-eslint/parser": "^5.12.0",
+        "async-retry": "^1.3.3",
         "conventional-changelog-angular": "^5.0.13",
         "eslint": "^8.9.0",
         "husky": "^7.0.4",
@@ -1369,6 +1371,15 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/@types/async-retry": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@types/async-retry/-/async-retry-1.4.4.tgz",
+      "integrity": "sha512-IGT+yESLPYje0MV8MfOpT5V5oH9lAKLwlosQRyq75tYJmntkkWcfEThHLxsgYjGmYXJEY7ZZkYPb4xuW+NA6GA==",
+      "dev": true,
+      "dependencies": {
+        "@types/retry": "*"
+      }
+    },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.93",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.93.tgz",
@@ -1549,6 +1560,12 @@
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.4.tgz",
       "integrity": "sha512-ReVR2rLTV1kvtlWFyuot+d1pkpG2Fw/XKE3PDAdj57rbM97ttSp9JZ2UsP+2EHTylra9cUf6JA7tGwW1INzUrA==",
+      "dev": true
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
       "dev": true
     },
     "node_modules/@types/semver": {
@@ -2072,6 +2089,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "dev": true,
+      "dependencies": {
+        "retry": "0.13.1"
       }
     },
     "node_modules/asynckit": {
@@ -5974,6 +6000,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -7559,6 +7594,7 @@
       "requires": {
         "@coveo/semantic-monorepo-tools": "file:",
         "@octokit/auth-app": "^3.6.1",
+        "@types/async-retry": "*",
         "@types/conventional-changelog-writer": "^4.0.1",
         "@types/conventional-commits-parser": "^3.0.2",
         "@types/debug": "^4.1.7",
@@ -7567,6 +7603,7 @@
         "@types/semver": "^7.3.9",
         "@typescript-eslint/eslint-plugin": "^5.12.0",
         "@typescript-eslint/parser": "^5.12.0",
+        "async-retry": "*",
         "conventional-changelog-angular": "^5.0.13",
         "conventional-changelog-writer": "^5.0.1",
         "conventional-commits-parser": "^3.2.4",
@@ -8675,6 +8712,15 @@
           "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
           "dev": true
         },
+        "@types/async-retry": {
+          "version": "1.4.4",
+          "resolved": "https://registry.npmjs.org/@types/async-retry/-/async-retry-1.4.4.tgz",
+          "integrity": "sha512-IGT+yESLPYje0MV8MfOpT5V5oH9lAKLwlosQRyq75tYJmntkkWcfEThHLxsgYjGmYXJEY7ZZkYPb4xuW+NA6GA==",
+          "dev": true,
+          "requires": {
+            "@types/retry": "*"
+          }
+        },
         "@types/aws-lambda": {
           "version": "8.10.93",
           "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.93.tgz",
@@ -8855,6 +8901,12 @@
           "version": "2.4.4",
           "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.4.tgz",
           "integrity": "sha512-ReVR2rLTV1kvtlWFyuot+d1pkpG2Fw/XKE3PDAdj57rbM97ttSp9JZ2UsP+2EHTylra9cUf6JA7tGwW1INzUrA==",
+          "dev": true
+        },
+        "@types/retry": {
+          "version": "0.12.2",
+          "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+          "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
           "dev": true
         },
         "@types/semver": {
@@ -9201,6 +9253,15 @@
           "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
           "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
           "dev": true
+        },
+        "async-retry": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+          "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+          "dev": true,
+          "requires": {
+            "retry": "0.13.1"
+          }
         },
         "asynckit": {
           "version": "0.4.0",
@@ -12142,6 +12203,12 @@
             "signal-exit": "^3.0.2"
           }
         },
+        "retry": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+          "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+          "dev": true
+        },
         "reusify": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -13625,6 +13692,15 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "@types/async-retry": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@types/async-retry/-/async-retry-1.4.4.tgz",
+      "integrity": "sha512-IGT+yESLPYje0MV8MfOpT5V5oH9lAKLwlosQRyq75tYJmntkkWcfEThHLxsgYjGmYXJEY7ZZkYPb4xuW+NA6GA==",
+      "dev": true,
+      "requires": {
+        "@types/retry": "*"
+      }
+    },
     "@types/aws-lambda": {
       "version": "8.10.93",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.93.tgz",
@@ -13805,6 +13881,12 @@
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.4.tgz",
       "integrity": "sha512-ReVR2rLTV1kvtlWFyuot+d1pkpG2Fw/XKE3PDAdj57rbM97ttSp9JZ2UsP+2EHTylra9cUf6JA7tGwW1INzUrA==",
+      "dev": true
+    },
+    "@types/retry": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
       "dev": true
     },
     "@types/semver": {
@@ -14151,6 +14233,15 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
+    },
+    "async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "dev": true,
+      "requires": {
+        "retry": "0.13.1"
+      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -17091,6 +17182,12 @@
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
       }
+    },
+    "retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "dev": true
     },
     "reusify": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@coveo/semantic-monorepo-tools": "file:.",
     "@octokit/auth-app": "^3.6.1",
+    "@types/async-retry": "^1.4.4",
     "@types/conventional-changelog-writer": "^4.0.1",
     "@types/conventional-commits-parser": "^3.0.2",
     "@types/debug": "^4.1.7",
@@ -44,6 +45,7 @@
     "@types/semver": "^7.3.9",
     "@typescript-eslint/eslint-plugin": "^5.12.0",
     "@typescript-eslint/parser": "^5.12.0",
+    "async-retry": "^1.3.3",
     "conventional-changelog-angular": "^5.0.13",
     "eslint": "^8.9.0",
     "husky": "^7.0.4",

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -27,6 +27,7 @@ import {
 import angularChangelogConvention from "conventional-changelog-angular";
 import { Octokit } from "octokit";
 import { createAppAuth } from "@octokit/auth-app";
+import retry from "async-retry";
 
 // Get all commits since last release bump the root package.json version.
 (async () => {
@@ -126,14 +127,9 @@ import { createAppAuth } from "@octokit/auth-app";
     tree: treeSHA,
     parents: [mainBranchCurrentSHA],
   });
-  // Forcefully reset `main` to the commit we just created with the GitHub API.
-  gitSetRefOnCommit("origin", `refs/heads/${mainBranchName}`, commit.data.sha);
 
-  // Push the branch. The app does need to be included in the 'Allow specified actors to bypass required pull requests' list of the protected branch.
-  gitCheckoutBranch(mainBranchName);
-  gitPush();
-  // Finally, delete the temp branch.
-  gitDeleteRemoteBranch("origin", tempBranchName);
+  // Forcefully reset our local `main` to the commit we just created with the GitHub API.
+  gitSetRefOnCommit("origin", `refs/heads/${mainBranchName}`, commit.data.sha);
   //#endregion
 
   //#region Create & push tag
@@ -153,5 +149,34 @@ import { createAppAuth } from "@octokit/auth-app";
     name: `Release ${newVersionTag}`,
     body: bodyArray.join("\n"),
   });
+  //#endregion
+
+  //#region Wait for CI to validate the released commit.
+  await retry(
+    (bail) => {
+      const releaseCheck = await octokit.rest.checks.listForRef({
+        owner: REPO_OWNER,
+        repo: REPO_NAME,
+        ref: commit.data.sha,
+        status: "completed",
+        filter: "latest",
+      });
+      if (releaseCheck.data.check_runs.length === 0) {
+        throw "No checks detected yet";
+      }
+      if (releaseCheck.data.check_runs[0].conclusion !== "success") {
+        bail(new Error("Check unsuccessful"));
+      }
+    },
+    { retries: 30 }
+  );
+  //#endregion
+
+  //#region Set `main` to the proper release.
+  // Push local main to remote. The app does need to be included in the 'Allow specified actors to bypass required pull requests' list of the protected branch.
+  gitCheckoutBranch(mainBranchName);
+  gitPush("origin", mainBranchName);
+  // Finally, delete the temp branch.
+  gitDeleteRemoteBranch("origin", tempBranchName);
   //#endregion
 })();


### PR DESCRIPTION
Even if the GH App is authorized to not go thru the PR process, it still needs to validate the 'Status Checks'.

This PR does that by following the GH doc on the topic:
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks

TL;DR:
 - Push the commit
 - Create a tag on the commit
 - Create a release on the commit
 - Release trigger a new dummy workflow that validates the check.
 - Wait for the check to go green.
 - Reset main to the commit.
 - Profit?