### PR TITLE
UITOOL-829/make filter optional for pnpm publish

### DIFF
--- a/src/pnpm/__tests__/doPnpmPublishVersion.spec.ts
+++ b/src/pnpm/__tests__/doPnpmPublishVersion.spec.ts
@@ -26,7 +26,7 @@ describe("doPnpmPublishVersions", () => {
   });
 
   it.each(["v1.0.0", "release-42"])(
-    `publishes recursively with the since %s filter`,
+    `publishes recursively with the since %s filter if defined`,
     async (since) => {
       await publish(since);
 
@@ -37,6 +37,16 @@ describe("doPnpmPublishVersions", () => {
       );
     }
   );
+
+  it(`publishes recursively without the since %s filter if not defined`, async () => {
+    await publish();
+
+    expect(mockedSpawn).toHaveBeenCalledWith(
+      "pnpm",
+      ["--recursive", "publish"],
+      {}
+    );
+  });
 
   it.each(["next", "alpha", "latest"])(
     "publishes with the %s tag",

--- a/src/pnpm/doPnpmPublishVersions.ts
+++ b/src/pnpm/doPnpmPublishVersions.ts
@@ -13,20 +13,17 @@ import pnpmLogger from "./utils/pnpmLogger.js";
  * @param excludePackages filter out the specified packages/directory from the output
  */
 export default async function (
-  since: string,
+  since?: string,
   tag?: string,
   branch?: string,
   forcePackages: string[] = [],
   excludePackages: string[] = []
 ) {
-  const pnpmArgs = [
-    "--recursive",
-    "--filter",
-    `...[${since}]`,
+  const pnpmArgs = ["--recursive"].concat(
+    getOptionalFlagArgument("--filter", `...[${since}]`),
     ...getIncludeFilters(forcePackages),
     ...getExclusionFilters(excludePackages),
     "publish",
-  ].concat(
     getOptionalFlagArgument("--tag", tag),
     getOptionalFlagArgument("--publish-branch", branch)
   );

--- a/src/pnpm/doPnpmPublishVersions.ts
+++ b/src/pnpm/doPnpmPublishVersions.ts
@@ -19,8 +19,10 @@ export default async function (
   forcePackages: string[] = [],
   excludePackages: string[] = []
 ) {
+  const filters = since ? `...[${since}]` : undefined;
+
   const pnpmArgs = ["--recursive"].concat(
-    getOptionalFlagArgument("--filter", `...[${since}]`),
+    getOptionalFlagArgument("--filter", filters),
     ...getIncludeFilters(forcePackages),
     ...getExclusionFilters(excludePackages),
     "publish",


### PR DESCRIPTION
JIra: https://coveord.atlassian.net/browse/UITOOL-829

I'm making the `since` argument in `doPnpmPublishVersions` optional so we can stop using it in the Plasma repository 🤞 
Added a test for this, making sure the command is not broken.

