### PR TITLE
chore: run security scan after release

### DIFF
--- a/.github/workflows/cron-scan.yml
+++ b/.github/workflows/cron-scan.yml
@@ -3,6 +3,11 @@ name: "Recurring Security Scan"
 on:
   schedule:
     - cron: "17 2 * * 2"
+  workflow_run:
+    workflows:
+      - CD
+    types:
+      - completed
 
 jobs:
   codeql:


### PR DESCRIPTION
## Proposed changes
Our Snyk gate run by comparing the report stored in GH Security Advisory for the head and base refs. Because we skip all CI for the commit created for the release, we have no report for a bit.
This fix that by running the workflow for Snyk on the master branch right after we completed the workflow for the release

## Testing
Yolo should work ™️


## References:
 - https://github.com/coveo/cli/pull/876 implementation in the CLI
 - [GitHub Documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run)