### PR TITLE
feat(npm-version): support workspace update

### DIFF
--- a/src/npm/__tests__/doNpmBumpVersion.ts
+++ b/src/npm/__tests__/doNpmBumpVersion.ts
@@ -1,0 +1,88 @@
+import type { Readable } from "node:stream";
+import { spawn, ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import npmBump from "../doNpmBumpVersion.js";
+import appendCmdIfWindows from "../utils/appendCmdIfWindows.js";
+
+jest.mock("node:child_process");
+const mockedSpawn = jest.mocked(spawn, true);
+
+jest.mock("../utils/appendCmdIfWindows.js");
+jest
+  .mocked(appendCmdIfWindows, true)
+  .mockImplementation((string: string) => string);
+
+const doMockDummySpawn = () => {
+  mockedSpawn.mockImplementation(() => {
+    const cpEventEmitter: ChildProcess = new EventEmitter() as ChildProcess;
+    const stdoutEventEmitter = new EventEmitter();
+    const stderrEventEmitter = new EventEmitter();
+    cpEventEmitter.stdout = stdoutEventEmitter as Readable;
+    cpEventEmitter.stderr = stderrEventEmitter as Readable;
+    setTimeout(() => {
+      cpEventEmitter.emit("close", 0);
+    }, 0);
+    return cpEventEmitter;
+  });
+};
+
+describe("npmPublish()", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    doMockDummySpawn();
+  });
+
+  describe("when no options is given", () => {
+    it("calls `npm version` with only --git-tag-version=false flag", async () => {
+      await npmBump("0.1.2", "somepath");
+
+      expect(mockedSpawn).toHaveBeenCalledWith(
+        appendCmdIfWindows`npm`,
+        ["version", "0.1.2", "--git-tag-version=false"],
+        { cwd: "somepath" }
+      );
+    });
+  });
+
+  describe("when options.NoUpdate is given", () => {
+    it("calls `npm version` with only --git-tag-version=false flag", async () => {
+      await npmBump("0.1.2", "somepath", {
+        workspaceUpdateStrategy: "NoUpdate",
+      });
+
+      expect(mockedSpawn).toHaveBeenCalledWith(
+        appendCmdIfWindows`npm`,
+        ["version", "0.1.2", "--git-tag-version=false"],
+        { cwd: "somepath" }
+      );
+    });
+  });
+
+  describe("when options.UpdateWithCarret is given", () => {
+    it("calls `npm version` with --save flag", async () => {
+      await npmBump("0.1.2", "somepath", {
+        workspaceUpdateStrategy: "UpdateWithCarret",
+      });
+
+      expect(mockedSpawn).toHaveBeenCalledWith(
+        appendCmdIfWindows`npm`,
+        ["version", "0.1.2", "--git-tag-version=false", "--save"],
+        { cwd: "somepath" }
+      );
+    });
+  });
+
+  describe("when options.UpdateExact is given", () => {
+    it("calls `npm version` with --save and -E flag", async () => {
+      await npmBump("0.1.2", "somepath", {
+        workspaceUpdateStrategy: "UpdateExact",
+      });
+
+      expect(mockedSpawn).toHaveBeenCalledWith(
+        appendCmdIfWindows`npm`,
+        ["version", "0.1.2", "--git-tag-version=false", "--save", "-E"],
+        { cwd: "somepath" }
+      );
+    });
+  });
+});

--- a/src/npm/doNpmBumpVersion.ts
+++ b/src/npm/doNpmBumpVersion.ts
@@ -2,10 +2,45 @@ import spawn from "../utils/spawn.js";
 import appendCmdIfWindows from "./utils/appendCmdIfWindows.js";
 import npmLogger from "./utils/npmLogger.js";
 
-export default async function (newVersion: string, PATH: string) {
-  const npmArgs = ["version", newVersion, "--git-tag-version=false"];
+type WorkspaceUpdateStrategy = "NoUpdate" | "UpdateWithCarret" | "UpdateExact";
+
+const DefaultOptions: Required<Options> = {
+  workspaceUpdateStrategy: "NoUpdate",
+};
+interface Options {
+  /**
+   * Define how to update the other packages of the workspace:
+   *  * `NoUpdate`: Do not update the other packages of the workspaces
+   *  * `UpdateWithCarret`: Update the other packages of the workspaces, with a loose specifier matching the inputed version
+   *  * `UpdateExact`: Update the other packages of the workspaces, with the inputed version (strict).
+   *
+   * @default {'NoUpdate'}
+   */
+  workspaceUpdateStrategy?: WorkspaceUpdateStrategy;
+}
+
+export default async function (
+  newVersion: string,
+  PATH: string,
+  options?: Options
+) {
+  const completeOptions: Required<Options> = { ...DefaultOptions, ...options };
+
+  const npmArgs = ["version", newVersion, "--git-tag-version=false"].concat(
+    computeFlagsFromOptions(completeOptions)
+  );
 
   await spawn(appendCmdIfWindows`npm`, npmArgs, npmLogger, {
     cwd: PATH,
   });
+}
+function computeFlagsFromOptions(options: Required<Options>) {
+  switch (options.workspaceUpdateStrategy) {
+    case "NoUpdate":
+      return [];
+    case "UpdateExact":
+      return ["--save", "-E"];
+    case "UpdateWithCarret":
+      return ["--save"];
+  }
 }


### PR DESCRIPTION
This is inspired by:
https://github.com/npm/cli/pull/4588


Since that, when running `npm version whatever --save`, you can update the other package.json that depends on a package.

So, if for example in a monorepo I have a depending on b, and I bump the version of b, with the --save flag I can update the version of b in a