### PR TITLE
fix(git): properly decode emojis

### DIFF
--- a/src/git/getCommits.ts
+++ b/src/git/getCommits.ts
@@ -24,7 +24,7 @@ export default async function (
   ].concat(getOptionalPositionalArgument(projectPath));
 
   const gitPs = await spawn("git", gitParams, gitLogger, {
-    encoding: "ascii",
+    encoding: "utf-8",
   });
   const commits = gitPs.stdout
     .split(delimiter)


### PR DESCRIPTION
https://git-scm.com/docs/git-commit/2.13.7#_discussion

UTF-8 is what's used by Git SCM. Decoding in ASCII mangle my emoji in my commits. I want... nay, demand! emojis in my commit.

Testing with UT would be hard, we should have FT for that, which seems a bit a waste of time for silly emojis.