### PR TITLE
fix(git): escape tag prefix

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -5,10 +5,20 @@
 
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 export default {
-  extensionsToTreatAsEsm: [".ts"],
-  preset: "ts-jest/presets/default-esm-legacy",
+  // [...]
+  preset: "ts-jest/presets/default-esm", // or other ESM presets
   moduleNameMapper: {
     "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
+  transform: {
+    // '^.+\\.[tj]sx?$' to process js/ts with `ts-jest`
+    // '^.+\\.m?[tj]sx?$' to process js/ts/mjs/mts with `ts-jest`
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      {
+        useESM: true,
+      },
+    ],
   },
 
   clearMocks: true,

--- a/src/git/__tests__/getLastGitTag.spec.ts
+++ b/src/git/__tests__/getLastGitTag.spec.ts
@@ -1,0 +1,51 @@
+import type { Readable } from "node:stream";
+import { spawn, ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import getLastGitTag from "../getLastGitTag.js";
+
+jest.mock("node:child_process");
+
+const mockedSpawn = jest.mocked(spawn);
+
+const doMockDummySpawn = () => {
+  mockedSpawn.mockImplementation(() => {
+    const cpEventEmitter: ChildProcess = new EventEmitter() as ChildProcess;
+    const stdoutEventEmitter = new EventEmitter();
+    const stderrEventEmitter = new EventEmitter();
+    cpEventEmitter.stdout = stdoutEventEmitter as Readable;
+    cpEventEmitter.stderr = stderrEventEmitter as Readable;
+    setTimeout(() => {
+      cpEventEmitter.emit("close", 0);
+    }, 0);
+    return cpEventEmitter;
+  });
+};
+
+describe("getLastGitTag()", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    doMockDummySpawn();
+  });
+
+  describe("when a prefix is provided", () => {
+    it("should call git describe with the --match flag set to the double-quoted prefix", async () => {
+      await getLastGitTag("somePrefix");
+      expect(mockedSpawn).toHaveBeenCalledWith(
+        "git",
+        ["describe", "--tags", "--abbrev=0", '--match="somePrefix*"'],
+        {}
+      );
+    });
+  });
+
+  describe("when no prefix is provided", () => {
+    it("should call git describe without the match flag", async () => {
+      await getLastGitTag();
+      expect(mockedSpawn).toHaveBeenCalledWith(
+        "git",
+        ["describe", "--tags", "--abbrev=0"],
+        {}
+      );
+    });
+  });
+});

--- a/src/git/getLastGitTag.ts
+++ b/src/git/getLastGitTag.ts
@@ -9,7 +9,7 @@ import gitLogger from "./utils/gitLogger.js";
 export default async function (prefix?: string): Promise<string> {
   const gitParams = ["describe", "--tags", "--abbrev=0"];
   if (prefix) {
-    gitParams.push(`--match=${prefix}*`);
+    gitParams.push(`--match="${prefix}*"`);
   }
   const gitPs = await spawn("git", gitParams, gitLogger);
 

--- a/src/npm/__tests__/doNpmBumpVersion.spec.ts
+++ b/src/npm/__tests__/doNpmBumpVersion.spec.ts
@@ -24,7 +24,7 @@ const doMockDummySpawn = () => {
   });
 };
 
-describe("npmPublish()", () => {
+describe("npmBump()", () => {
   beforeEach(() => {
     jest.resetAllMocks();
     doMockDummySpawn();


### PR DESCRIPTION
 - Escape the prefix parameter: We had an issue with [coveo/cli](https://github.com/coveo/cli) where, because our tags start with a`@` character, bash triggered a parameter expansion or something of the like (in short: it doesn't treat it as a classic character).
 This was not the intent of the function: parameter expansion is OS dependent, and this is a Node library that's meant to be x-OS comp.
 
 - Update jest config: It was failing due to some random ESM error that was not making any sense (when I added my new spec). Took a config sample of ts-config and slammed it in there, and it work.
 
 - src/npm/__tests__/doNpmBumpVersion.spec.ts: derp file name, derp spec name. Fixed.