### PR TITLE
ci(codeowners): change ui-tooling team for admin-console

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @coveo/ui-tooling @louis-bompart
+* @coveo/admin-console @louis-bompart


### PR DESCRIPTION
The ui-tooling team is getting disbanded in favour of the admin-console team