### PR TITLE
feat(git): add support for ref tagging

### DIFF
--- a/src/git/doGitTag.ts
+++ b/src/git/doGitTag.ts
@@ -1,6 +1,11 @@
+import getOptionalPositionalArgument from "../utils/getOptionalPositionalArgument.js";
 import spawn from "../utils/spawn.js";
 import gitLogger from "./utils/gitLogger.js";
 
-export default async function (tag: string) {
-  await spawn(`git`, ["tag", tag], gitLogger);
+export default async function (tag: string, commitSHA?: string) {
+  await spawn(
+    `git`,
+    ["tag", tag].concat(getOptionalPositionalArgument(commitSHA)),
+    gitLogger
+  );
 }


### PR DESCRIPTION
Allow doing: `git tag potato myCommitSHA1`