### PR TITLE
feat(git): allow force flag on gitSetRef

### DIFF
--- a/src/git/__tests__/doGitSetRefOnCommit.spec.ts
+++ b/src/git/__tests__/doGitSetRefOnCommit.spec.ts
@@ -27,4 +27,19 @@ describe("doGitSetRef()", () => {
       });
     }
   );
+
+  it("should append --force when force=true", async () => {
+    await gitSetRef("origin", "a", "b", true);
+    expect(mockedSpawn.mock.lastCall[1].pop()).toBe("--force");
+  });
+
+  it("should not append --force when force is unset", async () => {
+    await gitSetRef("origin", "a", "b");
+    expect(mockedSpawn.mock.lastCall[1].pop()).not.toBe("--force");
+  });
+
+  it("should not append --force when force=false", async () => {
+    await gitSetRef("origin", "a", "b", false);
+    expect(mockedSpawn.mock.lastCall[1].pop()).not.toBe("--force");
+  });
 });

--- a/src/git/doGitSetRefOnCommit.ts
+++ b/src/git/doGitSetRefOnCommit.ts
@@ -4,7 +4,8 @@ import gitLogger from "./utils/gitLogger.js";
 export default async function (
   remote: string,
   completeRef: string,
-  commitSha1: string
+  commitSha1: string,
+  force = false
 ) {
   const refPair = `${commitSha1}:${completeRef}`;
   if (refPair.startsWith("--") || remote.startsWith("--")) {
@@ -12,5 +13,9 @@ export default async function (
       `invalid param:${[remote, completeRef, commitSha1].join(",")}`
     );
   }
-  await spawn("git", ["fetch", remote, refPair], gitLogger);
+  await spawn(
+    "git",
+    ["fetch", remote, refPair].concat(force ? ["--force"] : []),
+    gitLogger
+  );
 }


### PR DESCRIPTION
> Whether that update is allowed without --force depends on the ref namespace it’s being fetched to, the type of object being fetched, and whether the update is considered to be a fast-forward. Generally, the same rules apply for fetching as when pushing, see the <refspec>... section of [git-push[1]](https://git-scm.com/docs/git-push) for what those are. Exceptions to those rules particular to git fetch are noted below.

https://git-scm.com/docs/git-fetch#Documentation/git-fetch.txt-ltrefspecgt

So, in essence: add a flag to allow non-fast-forward updates. 🧨