### PR TITLE
ci: use GH App authentication

### DIFF
--- a/.github/actions/dependabot/action.yml
+++ b/.github/actions/dependabot/action.yml
@@ -1,8 +1,30 @@
 name: "Setup"
 description: "Check for unaddressed Dependabot vulnerabilities"
+inputs:
+  appId:
+    description: GitHub App ID
+    required: true
+  privateKey:
+    description: GitHub App Private Key
+    required: true
+  clientId:
+    description: GitHub App Client Id
+    required: true
+  clientSecret:
+    description: GitHub App Client Secret
+    required: true
+  installationId:
+    description: GitHub Installation ID
+    required: true
 runs:
   using: composite
   steps:
     - name: Check Dependabot vulnerabilities
       run: node ./scripts/get-scan-results.mjs
       shell: bash
+      env:
+        RELEASER_APP_ID: ${{ inputs.RELEASER_APP_ID }}
+        RELEASER_PRIVATE_KEY: ${{ inputs.RELEASER_PRIVATE_KEY }}
+        RELEASER_CLIENT_ID: ${{ inputs.RELEASER_CLIENT_ID }}
+        RELEASER_CLIENT_SECRET: ${{ inputs.RELEASER_CLIENT_SECRET }}
+        RELEASER_INSTALLATION_ID: ${{ inputs.RELEASER_INSTALLATION_ID }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,6 +20,12 @@ jobs:
       - uses: ./.github/actions/lint
       - name: Dependabot
         uses: ./.github/actions/dependabot
+        with:
+          appId: ${{ secrets.RELEASER_APP_ID }}
+          privateKey: ${{ secrets.RELEASER_PRIVATE_KEY }}
+          clientId: ${{ secrets.RELEASER_CLIENT_ID }}
+          clientSecret: ${{ secrets.RELEASER_CLIENT_SECRET }}
+          installationId: ${{ secrets.RELEASER_INSTALLATION_ID }}
       - name: CodeQL
         uses: ./.github/actions/codeql
       - uses: ./.github/actions/build

--- a/scripts/get-scan-results.mjs
+++ b/scripts/get-scan-results.mjs
@@ -2,7 +2,18 @@ import { Octokit } from "octokit";
 
 const owner = "coveo";
 const repo = "semantic-monorepo-tools";
-const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
+const authSecrets = {
+  appId: process.env.RELEASER_APP_ID,
+  privateKey: process.env.RELEASER_PRIVATE_KEY,
+  clientId: process.env.RELEASER_CLIENT_ID,
+  clientSecret: process.env.RELEASER_CLIENT_SECRET,
+  installationId: process.env.RELEASER_INSTALLATION_ID,
+};
+
+const octokit = new Octokit({
+  authStrategy: createAppAuth,
+  auth: authSecrets,
+});
 const alerts = await octokit.rest.dependabot.listAlertsForRepo({
   owner,
   repo,


### PR DESCRIPTION
The default GITHUB_TOKEN generated by GitHub Action cannot be granted the permissions required (dependabotAlerts read).
I modified our app to have this right and use it to query.