### PR TITLE
fix: spawn npm thru ps1, not cmd

### DIFF
--- a/src/git/__tests__/getCommits.spec.ts
+++ b/src/git/__tests__/getCommits.spec.ts
@@ -43,7 +43,7 @@ describe("getCommits()", () => {
       "git",
       [
         "log",
-        "--pretty=format:%B%n-hash-%n%H <--- 23 --->",
+        '--pretty="format:%B%n-hash-%n%H <--- 23 --->"',
         "--dense",
         "someTag..HEAD",
         "somePath",
@@ -58,7 +58,7 @@ describe("getCommits()", () => {
       "git",
       [
         "log",
-        "--pretty=format:%B%n-hash-%n%H <--- 23 --->",
+        '--pretty="format:%B%n-hash-%n%H <--- 23 --->"',
         "--dense",
         "someTag..HEAD",
       ],

--- a/src/git/getCommits.ts
+++ b/src/git/getCommits.ts
@@ -15,7 +15,7 @@ export default async function (
   from: string,
   to = "HEAD",
 ): Promise<string[]> {
-  const delimiter = `<--- ${randomBytes(64).toString("hex")} --->`;
+  const delimiter = `"<--- ${randomBytes(64).toString("hex")} --->"`;
   const gitParams = [
     "log",
     `--pretty=format:%B%n-hash-%n%H ${delimiter}`,

--- a/src/git/getCommits.ts
+++ b/src/git/getCommits.ts
@@ -15,10 +15,10 @@ export default async function (
   from: string,
   to = "HEAD",
 ): Promise<string[]> {
-  const delimiter = `"<--- ${randomBytes(64).toString("hex")} --->"`;
+  const delimiter = `<--- ${randomBytes(64).toString("hex")} --->`;
   const gitParams = [
     "log",
-    `--pretty=format:%B%n-hash-%n%H ${delimiter}`,
+    `--pretty="format:%B%n-hash-%n%H ${delimiter}"`,
     "--dense",
     `${from}..${to}`,
   ].concat(getOptionalPositionalArgument(projectPath));

--- a/src/npm/utils/appendCmdIfWindows.ts
+++ b/src/npm/utils/appendCmdIfWindows.ts
@@ -1,3 +1,3 @@
 export default function appendCmdIfWindows(cmd) {
-  return `${cmd}${process.platform === "win32" ? ".cmd" : ""}`;
+  return `${cmd}${process.platform === "win32" ? ".ps1" : ""}`;
 }

--- a/src/utils/spawn.ts
+++ b/src/utils/spawn.ts
@@ -21,7 +21,11 @@ export default function (
   logger?.('executing "%s %s"', command, loggableArgs);
   let stdout = "";
   let stderr = "";
-  const { encoding, ...spawnOptions } = { encoding: "utf-8", ...options };
+  const { encoding, ...spawnOptions } = {
+    encoding: "utf-8",
+    ...options,
+    shell: process.platform === "win32" ? "powershell" : undefined,
+  };
 
   return new Promise<spawnOutputs>((resolve, reject) => {
     const childProcess = spawn(command, args, spawnOptions);

--- a/src/utils/spawn.ts
+++ b/src/utils/spawn.ts
@@ -23,8 +23,8 @@ export default function (
   let stderr = "";
   const { encoding, ...spawnOptions } = {
     encoding: "utf-8",
-    ...options,
     shell: process.platform === "win32" ? "powershell" : undefined,
+    ...options,
   };
 
   return new Promise<spawnOutputs>((resolve, reject) => {


### PR DESCRIPTION
Changes how we invoke NPM to work with Node latest security update: https://github.com/nodejs/node/commit/9095c914ed