### PR TITLE
fix: remove double quotes

### DIFF
--- a/src/git/__tests__/getCommits.spec.ts
+++ b/src/git/__tests__/getCommits.spec.ts
@@ -43,7 +43,7 @@ describe("getCommits()", () => {
       "git",
       [
         "log",
-        '--pretty="format:%B%n-hash-%n%H <--- 23 --->"',
+        "--format=%B%n-hash-%n%H%n<--- 23 --->",
         "--dense",
         "someTag..HEAD",
         "somePath",
@@ -58,7 +58,7 @@ describe("getCommits()", () => {
       "git",
       [
         "log",
-        '--pretty="format:%B%n-hash-%n%H <--- 23 --->"',
+        "--format=%B%n-hash-%n%H%n<--- 23 --->",
         "--dense",
         "someTag..HEAD",
       ],

--- a/src/git/getCommits.ts
+++ b/src/git/getCommits.ts
@@ -18,7 +18,7 @@ export default async function (
   const delimiter = `<--- ${randomBytes(64).toString("hex")} --->`;
   const gitParams = [
     "log",
-    `--pretty="format:%B%n-hash-%n%H ${delimiter}"`,
+    `--format=%B%n-hash-%n%H%n${delimiter}`,
     "--dense",
     `${from}..${to}`,
   ].concat(getOptionalPositionalArgument(projectPath));


### PR DESCRIPTION
and simplify git log flags

Currently, the getCommits will return all commit message prefixed with `format:` which means that the true scope of the commits is not recognized down the road etc: It's all 🗑️.

Fun fact, the command worked as intended on Windows, not on MacOS/Linux :finnadie:
