### PR TITLE
feat(git): allow additional args on gitDiff and getSHA1FromRef

### DIFF
--- a/src/git/doGitDiff.ts
+++ b/src/git/doGitDiff.ts
@@ -1,9 +1,13 @@
 import spawn from "../utils/spawn.js";
 import gitLogger from "./utils/gitLogger.js";
 
-export default async function gitDiff() {
+export default async function gitDiff(args: string[] = []): Promise<string[]> {
   return (
-    await spawn("git", ["--no-pager", "diff", "--name-only"], gitLogger)
+    await spawn(
+      "git",
+      ["--no-pager", "diff", "--name-only", ...args],
+      gitLogger,
+    )
   ).stdout
     .trim()
     .split("\n");

--- a/src/git/getSHA1FromRef.ts
+++ b/src/git/getSHA1FromRef.ts
@@ -1,6 +1,11 @@
 import spawn from "../utils/spawn.js";
 import gitLogger from "./utils/gitLogger.js";
 
-export default async function (ref: string) {
-  return (await spawn("git", ["rev-parse", ref], gitLogger)).stdout.trim();
+export default async function (
+  ref: string,
+  args: string[] = [],
+): Promise<string> {
+  return (
+    await spawn("git", ["rev-parse", ...args, ref], gitLogger)
+  ).stdout.trim();
 }


### PR DESCRIPTION
Adding an additional parameter on `gitDiff` and `getSHA1FromRef` that allows giving additional git arguments to these commands.