### PR TITLE
fix(pnpm): add --no-git-checks flag to bump version function

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ The goal is to make abstractions of the inner working of the tools (e.g. `git`, 
 It is also used for the release processes of several monorepos at Coveo, you can find implementations examples on some of our repository:
 
 - [`coveo/cli`](https://github.com/coveo/cli/blob/master/scripts/releaseV2)
-- [`coveo/plasma`](https://github.com/coveo/plasma/blob/master/build/publishNewVersion.mjs)
+- [`coveo/plasma`](https://github.com/coveo/plasma/blob/master/.github/actions/publish/index.mjs)

--- a/src/pnpm/__tests__/doPnpmBumpVersion.spec.ts
+++ b/src/pnpm/__tests__/doPnpmBumpVersion.spec.ts
@@ -30,7 +30,7 @@ describe("doPnpmBumpVersion", () => {
         "--recursive",
         '--filter="...[v0.0.0]"',
         "exec",
-        "pnpm version v1.0.0 --no-git-tag-version",
+        "pnpm version v1.0.0 --no-git-tag-version --no-git-checks",
       ],
       { shell: true },
     );
@@ -47,7 +47,7 @@ describe("doPnpmBumpVersion", () => {
         '--filter="@org/package-a"',
         '--filter="@org/package-b"',
         "exec",
-        "pnpm version v1.0.0 --no-git-tag-version",
+        "pnpm version v1.0.0 --no-git-tag-version --no-git-checks",
       ],
       { shell: true },
     );
@@ -64,7 +64,7 @@ describe("doPnpmBumpVersion", () => {
         '--filter="!@org/package-a"',
         '--filter="!@org/package-b"',
         "exec",
-        "pnpm version v1.0.0 --no-git-tag-version",
+        "pnpm version v1.0.0 --no-git-tag-version --no-git-checks",
       ],
       { shell: true },
     );
@@ -90,7 +90,7 @@ describe("doPnpmBumpVersion", () => {
         '--filter="!package-c"',
         '--filter="!package-d"',
         "exec",
-        "pnpm version v1.0.0 --no-git-tag-version",
+        "pnpm version v1.0.0 --no-git-tag-version --no-git-checks",
       ],
       { shell: true },
     );

--- a/src/pnpm/doPnpmBumpVersion.ts
+++ b/src/pnpm/doPnpmBumpVersion.ts
@@ -14,7 +14,7 @@ export default async function (
   excludePackages: string[] = [],
 ) {
   await runOnChanged(
-    `pnpm version ${newVersion} --no-git-tag-version`,
+    `pnpm version ${newVersion} --no-git-tag-version --no-git-checks`,
     since,
     forcePackages,
     excludePackages,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "moduleResolution": "Node16",
     "esModuleInterop": true,
     "sourceMap": false,
-    "declaration": true
+    "declaration": true,
+    "types": ["jest"]
   },
   "include": ["src"],
   "exclude": ["node_modules"]

--- a/tsconfig.sancheck.json
+++ b/tsconfig.sancheck.json
@@ -7,7 +7,9 @@
     "sourceMap": false,
     "allowJs": true,
     "noEmit": true,
-    "checkJs": true
+    "checkJs": true,
+    "strict": false,
+    "types": ["jest"]
   },
   "files": ["scripts/release.mjs"],
   "include": ["src"],


### PR DESCRIPTION
Adding the `--no-git-checks` flag to the `pnpm version` command. In version 11 of pnpm, it does not delegate the version command to `npm` anymore. NPM would not care about clean git worktrees. Adding the `--no-git-checks` preserves that behavior.